### PR TITLE
Avoid python 3 bytes error

### DIFF
--- a/linux.py
+++ b/linux.py
@@ -28,11 +28,8 @@ def get_active_window_raw():
     if match != None:
         ret = match.group("name").strip(b'"')
         #print(type(ret))
-        '''
-        ret is str for python2
-        ret is bytes for python3 (- gives error while calling in other file)
-        be careful
-        '''
+        if sys.version[0] == '3': # if compiler is python 3
+            return ret.decode()
         return ret
     return None
 

--- a/linux.py
+++ b/linux.py
@@ -28,7 +28,7 @@ def get_active_window_raw():
     if match != None:
         ret = match.group("name").strip(b'"')
         #print(type(ret))
-        if sys.version[0] == '3': # if compiler is python 3
+        if sys.version_info.major > 2:  # Python version is 3 or later
             return ret.decode()
         return ret
     return None


### PR DESCRIPTION
As described by author, python3 returned bytes causing future errors.